### PR TITLE
feat(proxy): support ProxyPluginResponse redirect

### DIFF
--- a/camellia-redis-proxy/camellia-redis-proxy-core/src/main/java/com/netease/nim/camellia/redis/proxy/command/CommandTask.java
+++ b/camellia-redis-proxy/camellia-redis-proxy-core/src/main/java/com/netease/nim/camellia/redis/proxy/command/CommandTask.java
@@ -3,13 +3,13 @@ package com.netease.nim.camellia.redis.proxy.command;
 import com.netease.nim.camellia.redis.proxy.plugin.ProxyPlugin;
 import com.netease.nim.camellia.redis.proxy.plugin.ProxyPluginResponse;
 import com.netease.nim.camellia.redis.proxy.plugin.ProxyReply;
+import com.netease.nim.camellia.redis.proxy.plugin.rewrite.RouteRewriteResult;
 import com.netease.nim.camellia.redis.proxy.reply.Reply;
 import com.netease.nim.camellia.redis.proxy.util.ErrorLogCollector;
 
 import java.util.List;
 
 /**
- *
  * Created by caojiajun on 2019/12/12.
  */
 public class CommandTask {
@@ -18,6 +18,34 @@ public class CommandTask {
     private final Command command;
     private final List<ProxyPlugin> plugins;
     private Reply reply;
+
+    private boolean isRedirect = false;
+
+    public boolean isRedirect() {
+        return isRedirect;
+    }
+
+    public void setRedirect(boolean redirect) {
+        isRedirect = redirect;
+    }
+
+    private long bidRedirect;
+
+    public long getBidRedirect() {
+        return bidRedirect;
+    }
+
+    private String bgroupRedirect;
+
+    public String getBgroupRedirect() {
+        return bgroupRedirect;
+    }
+
+    private boolean isSkipPlugins = false;
+
+    public void setSkipPlugins(boolean skipPlugins) {
+        isSkipPlugins = skipPlugins;
+    }
 
     public CommandTask(CommandTaskQueue taskQueue, Command command, List<ProxyPlugin> plugins) {
         this.command = command;
@@ -31,12 +59,19 @@ public class CommandTask {
 
     public void replyCompleted(Reply reply, boolean fromPlugin) {
         try {
-            if (plugins != null && !plugins.isEmpty()) {
+            if (!isSkipPlugins && plugins != null && !plugins.isEmpty()) {
                 ProxyReply proxyReply = new ProxyReply(command, reply, fromPlugin);
                 for (ProxyPlugin plugin : plugins) {
                     try {
                         ProxyPluginResponse response = plugin.executeReply(proxyReply);
                         if (!response.isPass()) {
+                            this.isRedirect = response.isRedirect();
+                            if (this.isRedirect) {
+                                RouteRewriteResult routeRewriterResult = response.getRouteRewriterResult();
+                                this.bidRedirect = routeRewriterResult.getBid();
+                                this.bgroupRedirect = routeRewriterResult.getBgroup();
+                            }
+
                             this.reply = response.getReply();
                             this.taskQueue.callback();
                             return;

--- a/camellia-redis-proxy/camellia-redis-proxy-core/src/main/java/com/netease/nim/camellia/redis/proxy/command/CommandsTransponder.java
+++ b/camellia-redis-proxy/camellia-redis-proxy-core/src/main/java/com/netease/nim/camellia/redis/proxy/command/CommandsTransponder.java
@@ -520,7 +520,17 @@ public class CommandsTransponder {
                 for (int i = 0; i < tasks.size(); i++) {
                     CommandTask task = tasks.get(i);
                     CompletableFuture<Reply> completableFuture = futureList.get(i);
-                    completableFuture.thenAccept(task::replyCompleted);
+                    completableFuture.thenAccept((reply -> {
+                        task.replyCompleted(reply);
+                        if (task.isRedirect()) {
+                            task.setRedirect(false);
+                            task.setSkipPlugins(true);
+
+                            long bidRedirect = task.getBidRedirect();
+                            String bgroupRedirect = task.getBgroupRedirect();
+                            flush(bidRedirect, bgroupRedirect, db, Collections.singletonList(task), Collections.singletonList(task.getCommand()));
+                        }
+                    }));
                 }
             }
         } catch (Exception e) {

--- a/camellia-redis-proxy/camellia-redis-proxy-core/src/main/java/com/netease/nim/camellia/redis/proxy/plugin/ProxyPluginResponse.java
+++ b/camellia-redis-proxy/camellia-redis-proxy-core/src/main/java/com/netease/nim/camellia/redis/proxy/plugin/ProxyPluginResponse.java
@@ -13,29 +13,44 @@ public class ProxyPluginResponse {
     public static final ProxyPluginResponse DEFAULT_FAIL = new ProxyPluginResponse(false, "ERR command proxy plugin no pass");
 
     private final boolean pass;
+    private final boolean isRedirect;
     private final Reply reply;
     private final RouteRewriteResult routeRewriteResult;//only request plugin can set this
 
     public ProxyPluginResponse(boolean pass, Reply reply) {
         this.pass = pass;
+        this.isRedirect = false;
         this.reply = reply;
         this.routeRewriteResult = null;
     }
 
     public ProxyPluginResponse(boolean pass, String errorMsg) {
         this.pass = pass;
+        this.isRedirect = false;
         this.reply = new ErrorReply(errorMsg);
         this.routeRewriteResult = null;
     }
 
     public ProxyPluginResponse(RouteRewriteResult routeRewriteResult) {
         this.pass = true;
+        this.isRedirect = false;
+        this.reply = null;
+        this.routeRewriteResult = routeRewriteResult;
+    }
+
+    public ProxyPluginResponse(boolean pass, boolean isRedirect, RouteRewriteResult routeRewriteResult) {
+        this.pass = isRedirect ? false : pass;
+        this.isRedirect = isRedirect;
         this.reply = null;
         this.routeRewriteResult = routeRewriteResult;
     }
 
     public boolean isPass() {
         return pass;
+    }
+
+    public boolean isRedirect() {
+        return isRedirect;
     }
 
     public Reply getReply() {


### PR DESCRIPTION
So I can create a plugin handle MOVED when using custom sharding.

eg.
`
    public ProxyPluginResponse executeReply(ProxyReply reply) {
        var redisReply = reply.getReply();
        var command = reply.getCommand();
        var context = command.getCommandContext();

        var bid = context.getBid();
        var bgroup = context.getBgroup();
        if (redisReply instanceof ErrorReply) {
            var error = ((ErrorReply) redisReply).getError();
            if (error != null && error.startsWith("MOVED")) {
                var alreadyContainsMoved = bgroup.contains(MOVED_IN_BGROUP);
                if (!alreadyContainsMoved) {
                    var arr = error.split(" ");
                    var slot = Integer.parseInt(arr[1]);
                    var hostWithPort = arr[2];

                    updateOneSlotTargetHostIpWhenGetMoveErrorReply(bid, bgroup, slot, hostWithPort);
                    logger.info("Update moved slot {} to {} for bid: {}.", slot, hostWithPort, bid);

                    var bgroupAddMoved = MontCacheProxyRouteConfUpdater.MOVED_IN_BGROUP + bgroup;
                    var routeRewriteResult = new RouteRewriteResult(bid, bgroupAddMoved);
                    var response = new ProxyPluginResponse(false, true, routeRewriteResult);
                    return response;
                }
            }
        }

        return ProxyPluginResponse.SUCCESS;
    }
`